### PR TITLE
Disable new index

### DIFF
--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.17.0.qualifier
+Bundle-Version: 3.17.0.lgc202112061111
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -5726,6 +5726,8 @@ public final class JavaCore extends Plugin {
 		IndexManager manager = JavaModelManager.getIndexManager();
 		manager.deleteIndexFiles(subMonitor.split(1));
 		manager.reset();
+		// New index is disabled, see bug 544898.
+		// However we keep this call here to cleanup the possibly existing database
 		Indexer.getInstance().rebuildIndex(subMonitor.split(95));
 		updateLegacyIndex(subMonitor.split(4));
 	}
@@ -6316,6 +6318,7 @@ public final class JavaCore extends Plugin {
 		super.start(context);
 		JavaModelManager.registerDebugOptionsListener(context);
 		JavaModelManager.getJavaModelManager().startup();
-		Indexer.getInstance().rescanAll();
+		// New index is disabled, see bug 544898
+		// Indexer.getInstance().rescanAll();
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaCorePreferenceInitializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaCorePreferenceInitializer.java
@@ -15,14 +15,17 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
 
-import org.eclipse.core.runtime.preferences.*;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.nd.db.ChunkCache;
-import org.eclipse.jdt.internal.core.nd.java.JavaIndex;
 
 /**
  * JavaCore eclipse preferences initializer.
@@ -113,8 +116,6 @@ public class JavaCorePreferenceInitializer extends AbstractPreferenceInitializer
 		defaultOptionsMap.put(ChunkCache.CHUNK_CACHE_SIZE_MB, Double.toString(ChunkCache.CHUNK_CACHE_SIZE_MB_DEFAULT));
 		defaultOptionsMap.put(ChunkCache.CHUNK_CACHE_SIZE_PERCENT,
 				Double.toString(ChunkCache.CHUNK_CACHE_SIZE_PERCENT_DEFAULT));
-		defaultOptionsMap.put(JavaIndex.ENABLE_NEW_JAVA_INDEX,
-				Boolean.toString(JavaIndex.ENABLE_NEW_JAVA_INDEX_DEFAULT));
 
 		// Time out for parameter names
 		defaultOptionsMap.put(JavaCore.TIMEOUT_FOR_PARAMETER_NAME_FROM_ATTACHED_JAVADOC, "50"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -5414,8 +5414,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					| IResourceChangeEvent.PRE_DELETE
 					| IResourceChangeEvent.PRE_CLOSE
 					| IResourceChangeEvent.PRE_REFRESH);
-
-			Indexer.getInstance().addListener(this.deltaState);
+			
+			// New index is disabled, see bug 544898
+			// Indexer.getInstance().addListener(this.deltaState);
 
 			// listen to resource changes affecting external annotations
 			ExternalAnnotationTracker.start(workspace);

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.17.0-SNAPSHOT</version>
+  <version>3.17.0.lgc202112061111</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/indexer/Indexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/indexer/Indexer.java
@@ -50,10 +50,6 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobGroup;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaElementDelta;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
@@ -73,7 +69,6 @@ import org.eclipse.jdt.internal.core.JavaModel;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.nd.IReader;
 import org.eclipse.jdt.internal.core.nd.Nd;
-import org.eclipse.jdt.internal.core.nd.db.ChunkCache;
 import org.eclipse.jdt.internal.core.nd.db.Database;
 import org.eclipse.jdt.internal.core.nd.db.IndexException;
 import org.eclipse.jdt.internal.core.nd.java.FileFingerprint;
@@ -102,18 +97,21 @@ public final class Indexer {
 	public static boolean DEBUG_INSERTIONS;
 	public static boolean DEBUG_SELFTEST;
 	public static int DEBUG_LOG_SIZE_MB;
-	private static IPreferenceChangeListener listener = new IPreferenceChangeListener() {
-		@Override
-		public void preferenceChange(PreferenceChangeEvent event) {
-			if (JavaIndex.ENABLE_NEW_JAVA_INDEX.equals(event.getKey())) {
-				if (JavaIndex.isEnabled()) {
-					getInstance().rescanAll();
-				} else {
-					ChunkCache.getSharedInstance().clear();
-				}
-			}
-		}
-	};
+	
+	// New index is disabled, see bug 544898
+//	private static final String ENABLE_NEW_JAVA_INDEX = "enableNewJavaIndex"; //$NON-NLS-1$
+//	private static IPreferenceChangeListener listener = new IPreferenceChangeListener() {
+//		@Override
+//		public void preferenceChange(PreferenceChangeEvent event) {
+//			if (ENABLE_NEW_JAVA_INDEX.equals(event.getKey())) {
+//				if (JavaIndex.isEnabled()) {
+//					getInstance().rescanAll();
+//				} else {
+//					ChunkCache.getSharedInstance().clear();
+//				}
+//			}
+//		}
+//	};
 
 	// This is an arbitrary constant that is larger than the maximum number of ticks
 	// reported by SubMonitor and small enough that it won't overflow a long when multiplied by a large
@@ -166,8 +164,8 @@ public final class Indexer {
 		synchronized (mutex) {
 			if (indexer == null) {
 				indexer = new Indexer(JavaIndex.getGlobalNd(), ResourcesPlugin.getWorkspace().getRoot());
-				IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
-				preferences.addPreferenceChangeListener(listener);
+//				IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+//				preferences.addPreferenceChangeListener(listener);
 			}
 			return indexer;
 		}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/JavaIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/JavaIndex.java
@@ -22,8 +22,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.core.JavaModelManager;
@@ -44,9 +42,6 @@ public class JavaIndex {
 	static final int CURRENT_VERSION = Nd.version(1, 49);
 	static final int MAX_SUPPORTED_VERSION = Nd.version(1, 49);
 	static final int MIN_SUPPORTED_VERSION = Nd.version(1, 49);
-
-	public static final String ENABLE_NEW_JAVA_INDEX = "enableNewJavaIndex"; //$NON-NLS-1$
-	public static final boolean ENABLE_NEW_JAVA_INDEX_DEFAULT = false;
 
 	// Fields for the search header
 	public static final FieldSearchIndex<NdResourceFile> FILES;
@@ -223,13 +218,11 @@ public class JavaIndex {
 		return next.getPath();
 	}
 
+	/**
+	 * @return always return {@code false} see bug 544898. New index is disabled now. 
+	 */
 	public static boolean isEnabled() {
-		IPreferencesService preferenceService = Platform.getPreferencesService();
-		if (preferenceService == null) {
-			return true;
-		}
-		return preferenceService.getBoolean(JavaCore.PLUGIN_ID, ENABLE_NEW_JAVA_INDEX, ENABLE_NEW_JAVA_INDEX_DEFAULT,
-				null);
+		return false;
 	}
 
 	public static Nd createNd(File databaseFile, ChunkCache chunkCache) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -56,8 +56,6 @@ import org.eclipse.jdt.internal.core.index.DiskIndex;
 import org.eclipse.jdt.internal.core.index.FileIndexLocation;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.index.IndexLocation;
-import org.eclipse.jdt.internal.core.nd.indexer.Indexer;
-import org.eclipse.jdt.internal.core.nd.java.JavaIndex;
 import org.eclipse.jdt.internal.core.search.BasicSearchEngine;
 import org.eclipse.jdt.internal.core.search.PatternSearchJob;
 import org.eclipse.jdt.internal.core.search.processing.IJob;
@@ -75,9 +73,9 @@ public class IndexManager extends JobManager implements IIndexConstants {
 	private SimpleLookupTable indexes = new SimpleLookupTable();
 
 	/**
-	 * The new indexer
+	 * The new indexer is disabled, see bug 544898
 	 */
-	private Indexer indexer = Indexer.getInstance();
+//	private Indexer indexer = Indexer.getInstance();
 
 	/* need to save ? */
 	private boolean needToSave = false;
@@ -255,7 +253,8 @@ private void deleteIndexFiles(SimpleSet pathsToKeep, IProgressMonitor monitor) {
  * Creates an empty index at the given location, for the given container path, if none exist.
  */
 public synchronized void ensureIndexExists(IndexLocation indexLocation, IPath containerPath) {
-	this.indexer.makeWorkspacePathDirty(containerPath);
+	// New index is disabled, see bug 544898
+    // this.indexer.makeWorkspacePathDirty(containerPath);
 	SimpleLookupTable states = getIndexStates();
 	Object state = states.get(indexLocation);
 	if (state == null) {
@@ -567,7 +566,8 @@ public void indexResolvedDocument(SearchDocument searchDocument, SearchParticipa
  * Note: the actual operation is performed in background
  */
 public void indexAll(IProject project) {
-	this.indexer.makeDirty(project);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeDirty(project);
 	if (JavaCore.getPlugin() == null) return;
 
 	try {
@@ -617,7 +617,8 @@ private boolean isJrt(String fileName) {
  * Note: the actual operation is performed in background
  */
 public void indexLibrary(IPath path, IProject requestingProject, URL indexURL, final boolean updateIndex) {
-	this.indexer.makeWorkspacePathDirty(path);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(path);
 	// requestingProject is no longer used to cancel jobs but leave it here just in case
 	IndexLocation indexFile = null;
 	boolean forceIndexUpdate = false;
@@ -673,7 +674,8 @@ synchronized boolean addIndex(IPath containerPath, IndexLocation indexFile) {
  */
 public void indexSourceFolder(JavaProject javaProject, IPath sourceFolder, char[][] inclusionPatterns, char[][] exclusionPatterns) {
 	IProject project = javaProject.getProject();
-	this.indexer.makeWorkspacePathDirty(sourceFolder);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(sourceFolder);
 	if (this.jobEnd > this.jobStart) {
 		// skip it if a job to index the project is already in the queue
 		IndexRequest request = new IndexAllProject(project, this);
@@ -736,7 +738,8 @@ private void rebuildIndex(IndexLocation indexLocation, IPath containerPath) {
 	rebuildIndex(indexLocation, containerPath, false);
 }
 private void rebuildIndex(IndexLocation indexLocation, IPath containerPath, final boolean updateIndex) {
-	this.indexer.makeWorkspacePathDirty(containerPath);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(containerPath);
 	Object target = JavaModel.getTarget(containerPath, true);
 	if (target == null) return;
 
@@ -795,7 +798,8 @@ public synchronized Index recreateIndex(IPath containerPath) {
  * Note: the actual operation is performed in background
  */
 public void remove(String containerRelativePath, IPath indexedContainer){
-	this.indexer.makeWorkspacePathDirty(indexedContainer);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(indexedContainer);
 	request(new RemoveFromIndex(containerRelativePath, indexedContainer, this));
 }
 /**
@@ -805,7 +809,8 @@ public void remove(String containerRelativePath, IPath indexedContainer){
 public synchronized void removeIndex(IPath containerPath) {
 	if (VERBOSE || DEBUG)
 		Util.verbose("removing index " + containerPath); //$NON-NLS-1$
-	this.indexer.makeWorkspacePathDirty(containerPath);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(containerPath);
 	IndexLocation indexLocation = computeIndexLocation(containerPath);
 	Index index = getIndex(indexLocation);
 	File indexFile = null;
@@ -835,7 +840,8 @@ public synchronized void removeIndex(IPath containerPath) {
 public synchronized void removeIndexPath(IPath path) {
 	if (VERBOSE || DEBUG)
 		Util.verbose("removing index path " + path); //$NON-NLS-1$
-	this.indexer.makeWorkspacePathDirty(path);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(path);
 	Object[] keyTable = this.indexes.keyTable;
 	Object[] valueTable = this.indexes.valueTable;
 	IndexLocation[] locations = null;
@@ -882,7 +888,8 @@ public synchronized void removeIndexPath(IPath path) {
  * Removes all indexes whose paths start with (or are equal to) the given path.
  */
 public synchronized void removeIndexFamily(IPath path) {
-	this.indexer.makeWorkspacePathDirty(path);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(path);
 	// only finds cached index files... shutdown removes all non-cached index files
 	ArrayList toRemove = null;
 	Object[] containerPaths = this.indexLocations.keyTable;
@@ -903,7 +910,8 @@ public synchronized void removeIndexFamily(IPath path) {
  * Remove the content of the given source folder from the index.
  */
 public void removeSourceFolderFromIndex(JavaProject javaProject, IPath sourceFolder, char[][] inclusionPatterns, char[][] exclusionPatterns) {
-	this.indexer.makeWorkspacePathDirty(sourceFolder);
+	// New index is disabled, see bug 544898
+	// this.indexer.makeWorkspacePathDirty(sourceFolder);
 	IProject project = javaProject.getProject();
 	if (this.jobEnd > this.jobStart) {
 		// skip it if a job to index the project is already in the queue
@@ -1046,10 +1054,11 @@ public void saveIndexes() {
 	this.needToSave = !allSaved;
 }
 public void scheduleDocumentIndexing(final SearchDocument searchDocument, IPath container, final IndexLocation indexLocation, final SearchParticipant searchParticipant) {
-	IPath targetLocation = JavaIndex.getLocationForPath(new Path(searchDocument.getPath()));
-	if (targetLocation != null) {
-		this.indexer.makeDirty(targetLocation);
-	}
+	// New index is disabled, see bug 544898
+//	IPath targetLocation = JavaIndex.getLocationForPath(new Path(searchDocument.getPath()));
+//	if (targetLocation != null) {
+//		 this.indexer.makeDirty(targetLocation);
+//	}
 	request(new IndexRequest(container, this) {
 		@Override
 		public boolean execute(IProgressMonitor progressMonitor) {


### PR DESCRIPTION
**Problem:** index.db file that opened for writing in temporary workspace folder and never close.  So when shutdown hook is trying to clean up temp workspace it fails because of opened for writing file index.db. As result on next run DSG user is getting message about abnormal shutdown.

This problem caused by "new Indexer" in org.eclipse.jdt.core plugin that turned off in R4_12 and fully removed in R4_21 because of plenty of defects.

**Solution:** backport turning of of ew indexer from R4_12 